### PR TITLE
feat: integrar CRUD de categorías y edición de stock en POS

### DIFF
--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { RolesModule } from './roles/roles.module';
 import { HealthController } from './health.controller';
 import { ProductsModule } from './products/products.module';
 import { InventoryModule } from './inventory/inventory.module';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
   imports: [
@@ -16,7 +17,8 @@ import { InventoryModule } from './inventory/inventory.module';
     AuthModule,     // módulo de auth (login/signup)
     RolesModule,    // módulo de roles
     ProductsModule, // módulo de productos (Prisma)
-  InventoryModule, // módulo de inventario (Prisma)
+    InventoryModule, // módulo de inventario (Prisma)
+    CategoriesModule, // módulo de categorías (Prisma)
     // 👇 si tu ProductModule lo migras a Prisma, puedes dejarlo
     // ProductModule,
   ],

--- a/Backend/src/categories/categories.controller.ts
+++ b/Backend/src/categories/categories.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+
+@Controller('api/categories')
+export class CategoriesController {
+  constructor(private readonly service: CategoriesService) {}
+
+  @Get()
+  findAll() { return this.service.findAll(); }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) { return this.service.findOne(id); }
+
+  @Post()
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('admin','superadmin')
+  create(@Body() dto: CreateCategoryDto) { return this.service.create(dto); }
+
+  @Patch(':id')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('admin','superadmin')
+  update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) { return this.service.update(id, dto); }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('admin','superadmin')
+  remove(@Param('id') id: string) { return this.service.remove(id); }
+}

--- a/Backend/src/categories/categories.module.ts
+++ b/Backend/src/categories/categories.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [CategoriesController],
+  providers: [CategoriesService],
+})
+export class CategoriesModule {}

--- a/Backend/src/categories/categories.service.ts
+++ b/Backend/src/categories/categories.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class CategoriesService {
+  constructor(private prisma: PrismaService) {}
+
+  create(dto: CreateCategoryDto) {
+    return this.prisma.categoria.create({ data: { nombre: dto.nombre.trim() } });
+  }
+
+  findAll() {
+    return this.prisma.categoria.findMany({ orderBy: { id_categoria: 'asc' } });
+  }
+
+  async findOne(id: string) {
+    const item = await this.prisma.categoria.findUnique({ where: { id_categoria: BigInt(id) } });
+    if (!item) throw new NotFoundException('Categoría no encontrada');
+    return item;
+  }
+
+  async update(id: string, dto: UpdateCategoryDto) {
+    try {
+      return await this.prisma.categoria.update({ where: { id_categoria: BigInt(id) }, data: { ...dto, ...(dto.nombre ? { nombre: dto.nombre.trim() } : {}) } });
+    } catch (e: any) {
+      if (e instanceof (Prisma as any).PrismaClientKnownRequestError && e.code === 'P2025') {
+        throw new NotFoundException('Categoría no encontrada');
+      }
+      if (e instanceof (Prisma as any).PrismaClientKnownRequestError && e.code === 'P2002') {
+        throw new BadRequestException('El nombre de categoría ya existe');
+      }
+      throw e;
+    }
+  }
+
+  async remove(id: string) {
+    try {
+      await this.prisma.categoria.delete({ where: { id_categoria: BigInt(id) } });
+      return { deleted: true };
+    } catch (e: any) {
+      if (e instanceof (Prisma as any).PrismaClientKnownRequestError && e.code === 'P2025') {
+        throw new NotFoundException('Categoría no encontrada');
+      }
+      throw e;
+    }
+  }
+}

--- a/Backend/src/categories/dto/create-category.dto.ts
+++ b/Backend/src/categories/dto/create-category.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateCategoryDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  nombre!: string;
+}

--- a/Backend/src/categories/dto/update-category.dto.ts
+++ b/Backend/src/categories/dto/update-category.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateCategoryDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(120)
+  nombre?: string;
+}

--- a/Docker/db/db_filacero.sql
+++ b/Docker/db/db_filacero.sql
@@ -376,3 +376,18 @@ INSERT INTO tipo_pago (tipo, descripcion) VALUES
 ON CONFLICT (tipo) DO NOTHING;
 
 -- Fin de bloque de hardening
+
+-- =============================================================
+-- Semillas iniciales de catálogo (categorías)
+-- =============================================================
+INSERT INTO categoria (nombre) VALUES
+  ('Bebidas'),
+  ('Alimentos'),
+  ('Postres'),
+  ('Snacks'),
+  ('Otros')
+ON CONFLICT (nombre) DO NOTHING;
+
+-- Índice simple por nombre (búsqueda)
+CREATE INDEX IF NOT EXISTS idx_categoria_nombre ON categoria (nombre);
+

--- a/Frontend/app/auth/register/page.tsx
+++ b/Frontend/app/auth/register/page.tsx
@@ -9,7 +9,6 @@ function RegisterPageWithRole() {
   const { setRole, reset } = useUserStore();
   const {
     step,
-    accountType,
     handleOwnerSelect,
     handleCustomerSelect,
     handleBackToSelection
@@ -34,7 +33,6 @@ function RegisterPageWithRole() {
   return (
     <RegisterLayout
       step={step}
-      accountType={accountType}
       onOwnerSelect={onOwner}
       onCustomerSelect={onCustomer}
       onBackToSelection={onBack}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   backend:
     build:
       context: ./Backend
-      dockerfile: Docker/backend.Dockerfile
+      dockerfile: ../Docker/backend.Dockerfile
     container_name: filacero-backend
     ports:
       - "3000:3000"


### PR DESCRIPTION
- semillas de categorías base (Bebidas, Alimentos, Postres, Snacks, Otros) con índice en la tabla `categoria`
- nuevo módulo Nest de categorías (controller + service + DTOs) protegido con roles admin/superadmin
- ajustes en `AppModule` y en `docker-compose.yml` para reconstruir correctamente el backend
- generación de paneles para editar productos y stock desde el POS (grid/list)
- integración de acciones Editar/Activar-Desactivar/Eliminar/Stock con recarga automática
- formulario de stock permite crear/actualizar inventario (usa NEXT_PUBLIC_NEGOCIO_ID o un ID manual)
- API `getInventory` acepta `id_negocio` opcional para buscar por producto
- ruta de registro ya no pasa `accountType` inexistente al layout